### PR TITLE
Fix PTHREAD_STACK_MIN macro handling for Boost build

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -3,6 +3,7 @@ $(package)_version=1_70_0
 $(package)_download_path=https://dl.bintray.com/boostorg/release/1.70.0/source/
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=430ae8354789de4fd19ee52f3b1f739e1fba576f0aded0897c3c2bc00fb38778
+$(package)_patches=fix_pthread_stack_min.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release

--- a/depends/patches/boost/fix_pthread_stack_min.patch
+++ b/depends/patches/boost/fix_pthread_stack_min.patch
@@ -1,0 +1,14 @@
+diff --git a/boost/thread/pthread/thread_data.hpp b/boost/thread/pthread/thread_data.hpp
+index 1234567..89abcdef 100644
+--- a/boost/thread/pthread/thread_data.hpp
++++ b/boost/thread/pthread/thread_data.hpp
+@@
+-#if defined(PTHREAD_STACK_MIN) && PTHREAD_STACK_MIN > 0
+-        if (size < PTHREAD_STACK_MIN)
+-            size = PTHREAD_STACK_MIN;
+-#endif
++#if defined(PTHREAD_STACK_MIN)
++        if (size < static_cast<std::size_t>(PTHREAD_STACK_MIN))
++            size = static_cast<std::size_t>(PTHREAD_STACK_MIN);
++#endif
+


### PR DESCRIPTION
## Summary
- add patch for Boost to handle dynamic `PTHREAD_STACK_MIN`
- apply patch during depends Boost build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f46fe4b18832abc1527ae73b2602c